### PR TITLE
commit reset & add env in dockerfile (must be fixed later : it should be…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN chmod +x /app/gradlew
 
 # Run the build process using Gradle wrapper
 RUN ./gradlew build --exclude-task test
+# RUN ./gradlew build
 
 # Stage 2: Create a minimal image to run the application
 FROM openjdk:17-alpine
@@ -27,6 +28,23 @@ COPY --from=build /app/build/libs/yomankum-0.0.1-SNAPSHOT.jar /app/yomankum.jar
 
 # Expose the port your application runs on (change as per your Spring Boot configuration)
 EXPOSE 8080
+
+ENV DATA_URL jdbc:mysql://cube.3trolls.me:13306/yomankum?useSSL=false&characterEncoding=UTF-8
+ENV DATA_USERNAME yomankum
+ENV DATA_PASSWORD in8282
+ENV NAVER_CLIENT_ID VVrviPtw50xif3PUsvby
+ENV NAVER_CLIENT_SECRET xGKXY5vHJP
+ENV KAKAO_CLIENT_ID de846ae383b9c41af8d14bcc90700379
+ENV KAKAO_CLIENT_SECRET otrfLjd6BmlQkRdBGyVSfsNbFDbD1G8t
+ENV MAIL_USERNAME y0mankum
+ENV MAIL_PASSWORD yomankum1004
+ENV MAIL_ID y0mankum
+ENV MYSQL_ROOT_PASSWORD in8282
+ENV MYSQL_USER yomankum
+ENV MYSQL_PASSWORD in8282
+ENV MYSQL_DATABASE yomankum
+ENV REDIS_HOST cube.3trolls.me
+ENV REDIS_PORT 16379
 
 # Command to run your Spring Boot application when the container starts
 CMD ["java", "-jar", "yomankum.jar"]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,8 +65,8 @@ spring:
       mail.smtp.ssl.enable: true
       mail.smtp.ssl.trust: smtp.naver.com
   redis:
-    host: localhost
-    port: 6379
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
 jasypt:
   encryptor:


### PR DESCRIPTION
… given in secret)

쿠버네티스에 redis 생성 해놓았고, application.yml에 레디스 주소와 포트를 환경변수 처리하는 것으로 바꿨습니다.

배포 서버 위 레디스 주소는 -h cube.3trolls.me -p 16379 입니다.
지금 레디스에 패스워드 입력 없이 접근 가능한 형태라서, 패드워드도 기입할 수 있게 코드 수정해주시면 감사하겠습니다. 

 휴일님께서 이제 개발하실 때는  application.yml을  application_dev.yml로 바꾸신 후에 db 와 redis 주소 localhost로 바꾸신 후에 dev 전용 버전으로 빌드하시면 될 것 같습니다.

앞선 설명에서 수정할 부분이 몇 가지 있습니다!
"자바 빌드 상에 테스트 태스크가 메인함수에서 디비 연동에 필수적으로 사용되는 것 같다는 점이고" => 이게 아니라, jar 파일 실행시에도 환경 변수가 필요했네요 ... 도커파일에 하드코딩으로 환경변수 추가해서 동작 확인했습니다.
