### PR TITLE
feat(sharedAccountBook): 엔티티 추가

### DIFF
--- a/src/main/java/com/account/yomankum/accountBook/controller/AccountBookController.java
+++ b/src/main/java/com/account/yomankum/accountBook/controller/AccountBookController.java
@@ -1,20 +1,14 @@
 package com.account.yomankum.accountBook.controller;
 
-import com.account.yomankum.accountBook.dto.response.AccountBookSimpleDto;
 import com.account.yomankum.accountBook.dto.request.AccountBookCreateRequest;
+import com.account.yomankum.accountBook.dto.response.AccountBookSimpleDto;
 import com.account.yomankum.accountBook.service.AccountBookFinder;
 import com.account.yomankum.accountBook.service.AccountBookService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/account/yomankum/accountBook/service/AccountBookFinder.java
+++ b/src/main/java/com/account/yomankum/accountBook/service/AccountBookFinder.java
@@ -6,12 +6,12 @@ import com.account.yomankum.accountBook.dto.response.AccountBookSimpleDto;
 import com.account.yomankum.common.exception.BadRequestException;
 import com.account.yomankum.common.exception.Exception;
 import com.account.yomankum.common.service.SessionService;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/account/yomankum/sharedAccountBook/SharedAccountBookFinder.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/SharedAccountBookFinder.java
@@ -1,0 +1,18 @@
+package com.account.yomankum.sharedAccountBook;
+
+import com.account.yomankum.sharedAccountBook.dto.response.SharedAccountBookSimpleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SharedAccountBookFinder {
+    @Transactional(readOnly = true)
+    public List<SharedAccountBookSimpleDto> findBySharedId(Long id) {
+        // dsadsa
+        return null;
+    }
+}

--- a/src/main/java/com/account/yomankum/sharedAccountBook/controller/SharedAccountBookController.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/controller/SharedAccountBookController.java
@@ -1,0 +1,28 @@
+package com.account.yomankum.sharedAccountBook.controller;
+
+import com.account.yomankum.sharedAccountBook.dto.response.SharedAccountBookSimpleDto;
+import com.account.yomankum.sharedAccountBook.SharedAccountBookFinder;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/account/shared")
+@Tag(name = "SharedAccountBook", description = "가계부 api")
+public class SharedAccountBookController {
+
+    private final SharedAccountBookFinder sharedAccountBookFinder;
+
+    @GetMapping("/{id}")
+    public List<SharedAccountBookSimpleDto> getSharedList(
+            @PathVariable Long id
+    ) {
+        return sharedAccountBookFinder.findBySharedId(id);
+    }
+}

--- a/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedAccountBookUser.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedAccountBookUser.java
@@ -1,0 +1,31 @@
+package com.account.yomankum.sharedAccountBook.domain;
+
+import com.account.yomankum.common.domain.TimeBaseEntity;
+import com.account.yomankum.user.domain.User;
+import jakarta.persistence.*;
+import jdk.jfr.Name;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SharedAccountBookUser extends TimeBaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Name("sharedAccountBookUser_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sharedInfo_id")
+    private SharedInfo sharedInfo;
+    private String nickname;
+    @Enumerated(EnumType.STRING)
+    private SharedRole sharedRole;
+}

--- a/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedInfo.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedInfo.java
@@ -1,0 +1,35 @@
+package com.account.yomankum.sharedAccountBook.domain;
+
+import com.account.yomankum.common.domain.TimeBaseEntity;
+import com.account.yomankum.user.domain.User;
+import jakarta.persistence.*;
+import jdk.jfr.Name;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class SharedInfo extends TimeBaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Name("sharedInfo_id")
+    private Long id;
+    private String name;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "masterUser_id")
+    private User masterUser;
+    @Enumerated(EnumType.STRING)
+    private SharedType sharedType;
+    @OneToMany(
+            mappedBy = "sharedInfo",
+            fetch = FetchType.LAZY,
+            cascade = CascadeType.REMOVE)
+    private List<SharedAccountBookUser> members;
+}

--- a/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedRole.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedRole.java
@@ -1,0 +1,8 @@
+package com.account.yomankum.sharedAccountBook.domain;
+
+public enum SharedRole {
+    OWNER,
+    MANAGER,
+    READ_ONLY,
+    READ_WRITE
+}

--- a/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedType.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/domain/SharedType.java
@@ -1,0 +1,18 @@
+package com.account.yomankum.sharedAccountBook.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SharedType {
+    FAMILY("가족"),
+    LOVER("연인"),
+    CLUB("모임"),
+    FRIENDS("친구"),
+    ETC("기타");
+
+    private final String title;
+
+    SharedType(String title) {
+        this.title = title;
+    }
+}

--- a/src/main/java/com/account/yomankum/sharedAccountBook/dto/response/SharedAccountBookSimpleDto.java
+++ b/src/main/java/com/account/yomankum/sharedAccountBook/dto/response/SharedAccountBookSimpleDto.java
@@ -1,0 +1,9 @@
+package com.account.yomankum.sharedAccountBook.dto.response;
+
+public record SharedAccountBookSimpleDto(
+        Long id,
+        String name,
+        String type,
+        String createdDateTime
+) {
+}

--- a/src/main/java/com/account/yomankum/user/domain/User.java
+++ b/src/main/java/com/account/yomankum/user/domain/User.java
@@ -1,5 +1,6 @@
 package com.account.yomankum.user.domain;
 
+import com.account.yomankum.sharedAccountBook.domain.SharedAccountBookUser;
 import com.account.yomankum.user.domain.type.Gender;
 import com.account.yomankum.user.dto.request.FirstLoginUserInfoSaveDto;
 import com.account.yomankum.user.dto.request.UserInfoUpdateDto;
@@ -8,6 +9,8 @@ import lombok.*;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,6 +33,13 @@ public class User {
     private Gender gender;
     private String job;
     private Integer salary;
+
+    @OneToMany(
+            mappedBy = "sharedAccountBook",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true,
+            fetch = FetchType.LAZY)
+    private List<SharedAccountBookUser> sharedAccountBookList = new ArrayList<>();
 
     private Instant joinDatetime;
     private Instant lastLoginDatetime; // 마지막 로그인이 NULL 일 경우, 첫 로그인


### PR DESCRIPTION
- 공유 가계부에만 있는 정보(가계부 이름, 운영자, 가계부타입(넣어도괜찮을지?), 멤버들) 관리를 위해 SharedInfo 추가
- 공유 가계부에 가입된 유저 정보를 넣기 위해 공유 가계부용 유저 정보 SharedAccountBookUser 추가
    - (닉네임,권한,어느 가계부에 소속되어있는지)

궁금한 점
- 가계부 타입 넣어도 괜찮을까요?
- 유저에게 본인이 가입된 공유 가계부 목록을 가져갈 수 있도록 OneToMany 시켰는데 굳이 추가 안 해도 될 것 같기도 하고 어떻게 생각하시나요?
- 다른 이상한 부분은 없을까요?

67